### PR TITLE
Download Bundle enchancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ You can also download a bundle in json format.
 
 No additional release notes at this time.
 
+### 0.1.1
+
+Enhancement: If there are no target languages,the sourceLanguage will be available as download option.
+
+### 0.1.0
+
+Fixes for Upload bundle for JSON and Java properties file.
+
 ### 0.0.7
 
 Added support for downloading to temp home folder when the user does not have permission to write to the current folder

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Globalization Pipeline Extension",
     "description": "Connect to the Globalization Pipeline service on Bluemix",
     "icon": "images/logo.svg",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "publisher": "IBM",
     "galleryBanner": {
         "color": "#f2f2f2",
@@ -123,7 +123,7 @@
     "devDependencies": {
         "gulp": "^3.9.1",
         "typescript": "^2.2.2",
-        "vscode": "^1.1.0",
+        "vscode": "^1.3.0",
         "gulp-install": "^1.1.0",
         "mocha": "^2.3.3",
         "@types/node": "^6.0.40",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -291,7 +291,12 @@ class GlobalizationPipeline {
                         _this.g11n.bundle(bundleName).getInfo({
                             fields: "targetLanguages"
                         }, function(err, langs) {
-                            if (err || langs.targetLanguages.length == 0) {
+                            if(typeof langs.targetLanguages === 'undefined'){
+                                var newTarget:string[]; 
+                                newTarget = ["en"]; 
+                                langs.targetLanguages = newTarget;
+                            }
+                            if (err) {
                                 window.showErrorMessage(localize(16, null));
                                 return;
                             }


### PR DESCRIPTION
* Updated vscode from v1.1.0 to v1.3.0 in package.json
* Updated README.md
*Updated Download Bundle when no targetLanguages are specified

Fixes https://github.com/IBM-Bluemix/gp-vscode-plugin/issues/14
Fixes: https://github.com/IBM-Bluemix/gp-vscode-plugin/issues/9
